### PR TITLE
Updates required for usage on Windows based workstations

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,1 @@
+end_of_line = lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Never modify line endings of our bash scripts
+*.sh -crlf

--- a/main.tf
+++ b/main.tf
@@ -12,17 +12,7 @@ resource "tls_private_key" "hashicat" {
 }
 
 locals {
-  private_key_filename = "hashicat-ssh-key.pem"
-}
-
-resource "null_resource" "create-ssh" {
-  provisioner "local-exec" {
-    command = "echo \"${tls_private_key.hashicat.private_key_pem}\" > ${local.private_key_filename}"
-  }
-
-  provisioner "local-exec" {
-    command = "chmod 600 ${local.private_key_filename}"
-  }
+  private_key_filename = "${var.prefix}-ssh-key.pem"
 }
 
 resource "aws_key_pair" "hashicat" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -2,3 +2,7 @@
 output "catapp_url" {
   value = "http://${aws_eip.hashicat.public_ip}"
 }
+
+output "private_key" {
+  value = "${tls_private_key.hashicat.private_key_pem}"
+}


### PR DESCRIPTION
This should make this a little bit more portable to both linux and windows based cloud workstations by eliminating the local-exec provisioner, as well as fixing the CR/LF issue with bash scripts. 
