### PR TITLE
Correction to outputs.tf.completed

### DIFF
--- a/exercises/outputs.tf.completed
+++ b/exercises/outputs.tf.completed
@@ -3,7 +3,6 @@ output "catapp_url" {
   value = "http://${aws_instance.hashicat.public_dns}"
 }
 
-
-output "private_key" {
-  value = "${tls_private_key.hashicat.private_key_pem}"
+output "catapp_ip" {
+  value = aws_eip.hashicat.public_ip
 }


### PR DESCRIPTION
Per the add-an-output exercise (Instruqt track), the second output should be "catapp_ip". I'm not sure why the private_key is in here. Removed private_key output and added catapp_ip.