### PR TITLE
add quotes around resource types

### DIFF
--- a/exercises/main.tf.completed
+++ b/exercises/main.tf.completed
@@ -3,7 +3,7 @@ provider "aws" {
   region  = var.region
 }
 
-resource aws_vpc "hashicat" {
+resource "aws_vpc" "hashicat" {
   cidr_block           = var.address_space
   enable_dns_hostnames = true
 
@@ -12,7 +12,7 @@ resource aws_vpc "hashicat" {
   }
 }
 
-resource aws_subnet "hashicat" {
+resource "aws_subnet" "hashicat" {
   vpc_id     = aws_vpc.hashicat.id
   cidr_block = var.subnet_prefix
 
@@ -21,7 +21,7 @@ resource aws_subnet "hashicat" {
   }
 }
 
-resource aws_security_group "hashicat" {
+resource "aws_security_group" "hashicat" {
   name = "${var.prefix}-security-group"
 
   vpc_id = aws_vpc.hashicat.id
@@ -60,12 +60,12 @@ resource aws_security_group "hashicat" {
   }
 }
 
-resource random_id "app-server-id" {
+resource "random_id" "app-server-id" {
   prefix      = "${var.prefix}-hashicat-"
   byte_length = 8
 }
 
-resource aws_internet_gateway "hashicat" {
+resource "aws_internet_gateway" "hashicat" {
   vpc_id = aws_vpc.hashicat.id
 
   tags = {
@@ -73,7 +73,7 @@ resource aws_internet_gateway "hashicat" {
   }
 }
 
-resource aws_route_table "hashicat" {
+resource "aws_route_table" "hashicat" {
   vpc_id = aws_vpc.hashicat.id
 
   route {
@@ -82,12 +82,12 @@ resource aws_route_table "hashicat" {
   }
 }
 
-resource aws_route_table_association "hashicat" {
+resource "aws_route_table_association" "hashicat" {
   subnet_id      = aws_subnet.hashicat.id
   route_table_id = aws_route_table.hashicat.id
 }
 
-data aws_ami "ubuntu" {
+data "aws_ami" "ubuntu" {
   most_recent = true
 
   filter {
@@ -114,7 +114,7 @@ resource "aws_eip_association" "hashicat" {
   allocation_id = aws_eip.hashicat.id
 }
 
-resource aws_instance "hashicat" {
+resource "aws_instance" "hashicat" {
   ami                         = data.aws_ami.ubuntu.id
   instance_type               = var.instance_type
   key_name                    = aws_key_pair.hashicat.key_name
@@ -178,7 +178,7 @@ resource "null_resource" "configure-cat-app" {
   }
 }
 
-resource tls_private_key "hashicat" {
+resource "tls_private_key" "hashicat" {
   algorithm = "RSA"
 }
 
@@ -186,7 +186,7 @@ locals {
   private_key_filename = "${var.prefix}-ssh-key.pem"
 }
 
-resource aws_key_pair "hashicat" {
+resource "aws_key_pair" "hashicat" {
   key_name   = local.private_key_filename
   public_key = tls_private_key.hashicat.public_key_openssh
 }

--- a/exercises/main.tf.cowsay
+++ b/exercises/main.tf.cowsay
@@ -3,7 +3,7 @@ provider "aws" {
   region  = var.region
 }
 
-resource aws_vpc "hashicat" {
+resource "aws_vpc" "hashicat" {
   cidr_block           = var.address_space
   enable_dns_hostnames = true
 
@@ -12,7 +12,7 @@ resource aws_vpc "hashicat" {
   }
 }
 
-resource aws_subnet "hashicat" {
+resource "aws_subnet" "hashicat" {
   vpc_id     = aws_vpc.hashicat.id
   cidr_block = var.subnet_prefix
 
@@ -21,7 +21,7 @@ resource aws_subnet "hashicat" {
   }
 }
 
-resource aws_security_group "hashicat" {
+resource "aws_security_group" "hashicat" {
   name = "${var.prefix}-security-group"
 
   vpc_id = aws_vpc.hashicat.id
@@ -60,12 +60,12 @@ resource aws_security_group "hashicat" {
   }
 }
 
-resource random_id "app-server-id" {
+resource "random_id" "app-server-id" {
   prefix      = "${var.prefix}-hashicat-"
   byte_length = 8
 }
 
-resource aws_internet_gateway "hashicat" {
+resource "aws_internet_gateway" "hashicat" {
   vpc_id = aws_vpc.hashicat.id
 
   tags = {
@@ -73,7 +73,7 @@ resource aws_internet_gateway "hashicat" {
   }
 }
 
-resource aws_route_table "hashicat" {
+resource "aws_route_table" "hashicat" {
   vpc_id = aws_vpc.hashicat.id
 
   route {
@@ -82,12 +82,12 @@ resource aws_route_table "hashicat" {
   }
 }
 
-resource aws_route_table_association "hashicat" {
+resource "aws_route_table_association" "hashicat" {
   subnet_id      = aws_subnet.hashicat.id
   route_table_id = aws_route_table.hashicat.id
 }
 
-data aws_ami "ubuntu" {
+data "aws_ami" "ubuntu" {
   most_recent = true
 
   filter {
@@ -114,7 +114,7 @@ resource "aws_eip_association" "hashicat" {
   allocation_id = aws_eip.hashicat.id
 }
 
-resource aws_instance "hashicat" {
+resource "aws_instance" "hashicat" {
   ami                         = data.aws_ami.ubuntu.id
   instance_type               = var.instance_type
   key_name                    = aws_key_pair.hashicat.key_name
@@ -180,7 +180,7 @@ resource "null_resource" "configure-cat-app" {
   }
 }
 
-resource tls_private_key "hashicat" {
+resource "tls_private_key" "hashicat" {
   algorithm = "RSA"
 }
 
@@ -188,7 +188,7 @@ locals {
   private_key_filename = "${var.prefix}-ssh-key.pem"
 }
 
-resource aws_key_pair "hashicat" {
+resource "aws_key_pair" "hashicat" {
   key_name   = local.private_key_filename
   public_key = tls_private_key.hashicat.public_key_openssh
 }

--- a/exercises/main.tf.start
+++ b/exercises/main.tf.start
@@ -3,17 +3,17 @@ provider "aws" {
   region  = var.region
 }
 
-resource aws_vpc "hashicat" {
+resource "aws_vpc" "hashicat" {
   cidr_block           = var.address_space
   enable_dns_hostnames = true
-  
+
   tags = {
     name = "${var.prefix}-vpc"
   }
-  
+
 }
 
-# resource aws_subnet "hashicat" {
+# resource "aws_subnet" "hashicat" {
 #   vpc_id     = aws_vpc.hashicat.id
 #   cidr_block = var.subnet_prefix
 
@@ -22,7 +22,7 @@ resource aws_vpc "hashicat" {
 #   }
 # }
 
-# resource aws_security_group "hashicat" {
+# resource "aws_security_group" "hashicat" {
 #   name = "${var.prefix}-security-group"
 
 #   vpc_id = aws_vpc.hashicat.id
@@ -61,12 +61,12 @@ resource aws_vpc "hashicat" {
 #   }
 # }
 
-# resource random_id "app-server-id" {
+# resource "random_id" "app-server-id" {
 #   prefix      = "${var.prefix}-hashicat-"
 #   byte_length = 8
 # }
 
-# resource aws_internet_gateway "hashicat" {
+# resource "aws_internet_gateway" "hashicat" {
 #   vpc_id = aws_vpc.hashicat.id
 
 #   tags = {
@@ -74,7 +74,7 @@ resource aws_vpc "hashicat" {
 #   }
 # }
 
-# resource aws_route_table "hashicat" {
+# resource "aws_route_table" "hashicat" {
 #   vpc_id = aws_vpc.hashicat.id
 
 #   route {
@@ -83,12 +83,12 @@ resource aws_vpc "hashicat" {
 #   }
 # }
 
-# resource aws_route_table_association "hashicat" {
+# resource "aws_route_table_association" "hashicat" {
 #   subnet_id      = aws_subnet.hashicat.id
 #   route_table_id = aws_route_table.hashicat.id
 # }
 
-# data aws_ami "ubuntu" {
+# data "aws_ami" "ubuntu" {
 #   most_recent = true
 
 #   filter {
@@ -115,7 +115,7 @@ resource aws_vpc "hashicat" {
 #   allocation_id = aws_eip.hashicat.id
 # }
 
-# resource aws_instance "hashicat" {
+# resource "aws_instance" "hashicat" {
 #   ami                         = data.aws_ami.ubuntu.id
 #   instance_type               = var.instance_type
 #   key_name                    = aws_key_pair.hashicat.key_name
@@ -179,7 +179,7 @@ resource aws_vpc "hashicat" {
 #   }
 # }
 
-# resource tls_private_key "hashicat" {
+# resource "tls_private_key" "hashicat" {
 #   algorithm = "RSA"
 # }
 
@@ -187,7 +187,7 @@ resource aws_vpc "hashicat" {
 #   private_key_filename = "${var.prefix}-ssh-key.pem"
 # }
 
-# resource aws_key_pair "hashicat" {
+# resource "aws_key_pair" "hashicat" {
 #   key_name   = local.private_key_filename
 #   public_key = tls_private_key.hashicat.public_key_openssh
 # }

--- a/main.tf
+++ b/main.tf
@@ -3,7 +3,7 @@ provider "aws" {
   region  = var.region
 }
 
-resource aws_vpc "hashicat" {
+resource "aws_vpc" "hashicat" {
   cidr_block           = var.address_space
   enable_dns_hostnames = true
 
@@ -12,7 +12,7 @@ resource aws_vpc "hashicat" {
   }
 }
 
-resource aws_subnet "hashicat" {
+resource "aws_subnet" "hashicat" {
   vpc_id     = aws_vpc.hashicat.id
   cidr_block = var.subnet_prefix
 
@@ -21,7 +21,7 @@ resource aws_subnet "hashicat" {
   }
 }
 
-resource aws_security_group "hashicat" {
+resource "aws_security_group" "hashicat" {
   name = "${var.prefix}-security-group"
 
   vpc_id = aws_vpc.hashicat.id
@@ -60,12 +60,12 @@ resource aws_security_group "hashicat" {
   }
 }
 
-resource random_id "app-server-id" {
+resource "random_id" "app-server-id" {
   prefix      = "${var.prefix}-hashicat-"
   byte_length = 8
 }
 
-resource aws_internet_gateway "hashicat" {
+resource "aws_internet_gateway" "hashicat" {
   vpc_id = aws_vpc.hashicat.id
 
   tags = {
@@ -73,7 +73,7 @@ resource aws_internet_gateway "hashicat" {
   }
 }
 
-resource aws_route_table "hashicat" {
+resource "aws_route_table" "hashicat" {
   vpc_id = aws_vpc.hashicat.id
 
   route {
@@ -82,12 +82,12 @@ resource aws_route_table "hashicat" {
   }
 }
 
-resource aws_route_table_association "hashicat" {
+resource "aws_route_table_association" "hashicat" {
   subnet_id      = aws_subnet.hashicat.id
   route_table_id = aws_route_table.hashicat.id
 }
 
-data aws_ami "ubuntu" {
+data "aws_ami" "ubuntu" {
   most_recent = true
 
   filter {
@@ -114,7 +114,7 @@ resource "aws_eip_association" "hashicat" {
   allocation_id = aws_eip.hashicat.id
 }
 
-resource aws_instance "hashicat" {
+resource "aws_instance" "hashicat" {
   ami                         = data.aws_ami.ubuntu.id
   instance_type               = var.instance_type
   key_name                    = aws_key_pair.hashicat.key_name
@@ -178,7 +178,7 @@ resource "null_resource" "configure-cat-app" {
   }
 }
 
-resource tls_private_key "hashicat" {
+resource "tls_private_key" "hashicat" {
   algorithm = "RSA"
 }
 
@@ -186,7 +186,7 @@ locals {
   private_key_filename = "${var.prefix}-ssh-key.pem"
 }
 
-resource aws_key_pair "hashicat" {
+resource "aws_key_pair" "hashicat" {
   key_name   = local.private_key_filename
   public_key = tls_private_key.hashicat.public_key_openssh
 }


### PR DESCRIPTION
Adding double quotes around resource types since that is the normal thing and since it should match hashi-azure and hashi-gcp apps. Also, so validate challenge behaves better.