### PR TITLE
use required_providers and v3.42.0

### DIFF
--- a/exercises/main.tf.completed
+++ b/exercises/main.tf.completed
@@ -1,5 +1,13 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "=3.42.0"
+    }
+  }
+}
+
 provider "aws" {
-  version = "~> 3.0"
   region  = var.region
 }
 

--- a/exercises/main.tf.cowsay
+++ b/exercises/main.tf.cowsay
@@ -1,5 +1,13 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "=3.42.0"
+    }
+  }
+}
+
 provider "aws" {
-  version = "~> 3.0"
   region  = var.region
 }
 

--- a/exercises/main.tf.start
+++ b/exercises/main.tf.start
@@ -1,5 +1,13 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "=3.42.0"
+    }
+  }
+}
+
 provider "aws" {
-  version = "~> 3.0"
   region  = var.region
 }
 

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,13 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "=3.42.0"
+    }
+  }
+}
+
 provider "aws" {
-  version = "~> 3.0"
   region  = var.region
 }
 


### PR DESCRIPTION
To support use of TF 0.14.9 and avoid deprecation warnings