### PR TITLE
Remove Terraform helper installer

### DIFF
--- a/files/install_tfh.sh
+++ b/files/install_tfh.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-cd ~
-rm -rf tf-helper
-# rm -rf ~/.terraformrc
-git clone https://github.com/hashicorp-community/tf-helper.git
-cd tf-helper/tfh/bin
-echo "export PATH=$PWD:\$PATH" > ~/.bash_profile
-echo "Script complete. Run 'source ~/.bash_profile' to enable the tfh command."


### PR DESCRIPTION
The terraform helper is deprecated and no longer in use in any tracks or training material.